### PR TITLE
Add Gradle Enterprise badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.micronaut.rxjava3/micronaut-rxjava3.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.micronaut.rxjava3%22%20AND%20a:%22micronaut-rxjava3%22)
 [![Build Status](https://github.com/micronaut-projects/micronaut-rxjava3/workflows/Java%20CI/badge.svg)](https://github.com/micronaut-projects/micronaut-rxjava3/actions)
+[![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.micronaut.io/scans)
 
 Integration between Micronaut and RxJava 3 
 


### PR DESCRIPTION
While checking the build scan in GE, I found out that you have a typo in settings.gradle: `rootProject.name = 'rxjaxa3'`, (note that this PR does not changed it to `rxjava3`)