### PR TITLE
Allow closing RxHttpClients

### DIFF
--- a/rxjava3-http-client/src/main/java/io/micronaut/rxjava3/http/client/BridgedRx3HttpClient.java
+++ b/rxjava3-http-client/src/main/java/io/micronaut/rxjava3/http/client/BridgedRx3HttpClient.java
@@ -108,4 +108,23 @@ class BridgedRx3HttpClient implements Rx3HttpClient {
     public boolean isRunning() {
         return httpClient.isRunning();
     }
+
+    @Override
+    public void close() {
+        httpClient.close();
+    }
+
+    @Override
+    @NonNull
+    public HttpClient start() {
+        httpClient.start();
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public HttpClient stop() {
+        httpClient.stop();
+        return this;
+    }
 }

--- a/rxjava3-http-client/src/test/groovy/io/micronaut/rxjava3/http/client/RxClientCloseSpec.groovy
+++ b/rxjava3-http-client/src/test/groovy/io/micronaut/rxjava3/http/client/RxClientCloseSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.rxjava3.http.client
+
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class RxClientCloseSpec extends Specification {
+    def "confirm RxHttpClient can be stopped"() {
+        given:
+        def client = Rx3HttpClient.create(new URL("http://localhost"))
+
+        expect:
+        client.isRunning()
+
+        when:
+        client.stop()
+        then:
+        new PollingConditions().eventually {
+            !client.isRunning()
+        }
+    }
+
+    def "confirm RxHttpClient can be closed"() {
+        given:
+        def client = Rx3HttpClient.create(new URL("http://localhost"))
+
+        expect:
+        client.isRunning()
+
+        when:
+        client.close()
+        then:
+        new PollingConditions().eventually {
+            !client.isRunning()
+        }
+    }
+}


### PR DESCRIPTION
The delegation for close, start and stop were missing.
Same patch as https://github.com/micronaut-projects/micronaut-rxjava2/pull/51