### PR TITLE
Propagate context when converting from Publisher to RxJava type

### DIFF
--- a/rxjava3-http-client/src/test/groovy/io/micronaut/rxjava3/http/client/ServerRequestContextSpec.groovy
+++ b/rxjava3-http-client/src/test/groovy/io/micronaut/rxjava3/http/client/ServerRequestContextSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.rxjava3.http.client
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.async.annotation.SingleResult
+import io.micronaut.core.io.buffer.ByteBuffer
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -11,16 +12,17 @@ import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.context.ServerRequestContext
 import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Named
 import org.reactivestreams.Publisher
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import jakarta.inject.Inject
-import jakarta.inject.Named
-
+import java.nio.charset.Charset
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 
@@ -37,16 +39,54 @@ class ServerRequestContextSpec extends Specification {
         testClient."$method"() == uri
 
         where:
-        method          | uri
-        "rxjava"        | '/test-context/rxjava'
+        method                      | uri
+        "rxjavaSingle"              | '/test-context/rxjava-single'
+        "rxjavaSingleScheduled"     | '/test-context/rxjava-single-scheduled'
+        "rxjavaFlowable"            | '/test-context/rxjava-flowable'
+        "rxjavaFlowableScheduled"   | '/test-context/rxjava-flowable-scheduled'
+    }
+
+    @Unroll
+    void "test server request context is available in nested client call for #method"() {
+        given:
+        def expected = "pong : "+uri
+
+        expect:
+        testClient."$method"().blockingGet() == expected
+
+        where:
+        method                      | uri
+        "rxjavaSingleClient"        | '/test-context/rxjava-single-client'
+        "rxjavaFlowableClient"      | '/test-context/rxjava-flowable-client'
     }
 
     @Client('/test-context')
     @Consumes(MediaType.TEXT_PLAIN)
     static interface TestClient {
 
-        @Get("/rxjava")
-        String rxjava()
+        @Get("/rxjava-single")
+        String rxjavaSingle()
+
+        @Get("/rxjava-single-scheduled")
+        String rxjavaSingleScheduled()
+
+        @Get("/rxjava-flowable")
+        String rxjavaFlowable()
+
+        @Get("/rxjava-flowable-scheduled")
+        String rxjavaFlowableScheduled()
+
+        @Get("/ping")
+        Single<String> ping()
+
+        @Get("/ping")
+        Flowable<ByteBuffer> pingMany()
+
+        @Get("/rxjava-single-client")
+        Single<String> rxjavaSingleClient()
+
+        @Get("/rxjava-flowable-client")
+        Single<String> rxjavaFlowableClient()
     }
 
     @Controller('/test-context')
@@ -57,9 +97,29 @@ class ServerRequestContextSpec extends Specification {
         @Named(TaskExecutors.IO)
         ExecutorService executorService
 
-        @Get("/rxjava")
+        @Inject
+        TestClient pingClient
+
+        @Get("/ping")
+        String ping() {
+            return "pong"
+        }
+
+        @Get("/rxjava-single")
         @SingleResult
-        Publisher<String> rxjava() {
+        Publisher<String> rxjavaSingle() {
+            Single.fromCallable(new Callable<String>() {
+                @Override
+                String call() throws Exception {
+                    HttpRequest<?> request = ServerRequestContext.currentRequest().orElseThrow { -> new RuntimeException("no request") }
+                    request.uri
+                }
+            }).toFlowable()
+        }
+
+        @Get("/rxjava-single-scheduled")
+        @SingleResult
+        Publisher<String> rxjavaSingleScheduled() {
             Single.fromCallable(new Callable<String>() {
                 @Override
                 String call() throws Exception {
@@ -67,6 +127,56 @@ class ServerRequestContextSpec extends Specification {
                     request.uri
                 }
             }).subscribeOn(Schedulers.computation()).toFlowable()
+        }
+
+        @Get("/rxjava-flowable")
+        @SingleResult
+        Publisher<String> rxjavaFlowable() {
+            Flowable.fromCallable(new Callable<String>() {
+                @Override
+                String call() throws Exception {
+                    HttpRequest<?> request = ServerRequestContext.currentRequest().orElseThrow { -> new RuntimeException("no request") }
+                    request.uri
+                }
+            })
+        }
+
+        @Get("/rxjava-flowable-scheduled")
+        @SingleResult
+        Publisher<String> rxjavaFlowableScheduled() {
+            Flowable.fromCallable(new Callable<String>() {
+                @Override
+                String call() throws Exception {
+                    HttpRequest<?> request = ServerRequestContext.currentRequest().orElseThrow { -> new RuntimeException("no request") }
+                    request.uri
+                }
+            }).subscribeOn(Schedulers.computation())
+        }
+
+        @Get("/rxjava-single-client")
+        @SingleResult
+        Publisher<String> rxjavaSingleClient() {
+            pingClient.ping().map(response -> {
+                HttpRequest<?> request = ServerRequestContext.currentRequest().orElseThrow { -> new RuntimeException("no request") }
+                return response +" : "+request.uri
+            }).toFlowable()
+        }
+
+        @Get("/rxjava-flowable-client")
+        @SingleResult
+        Publisher<String> rxjavaFlowableClient() {
+            pingClient.pingMany()
+                    .map(chunk -> {
+                        return chunk.toString(Charset.defaultCharset())
+                    })
+                    .toList()
+                    .flatMapPublisher(response -> {
+                        ServerRequestContext.currentRequest()
+                        .map(request -> Flowable.just(response.get(0) +" : "+request.uri))
+                        .orElse(Flowable.error(() -> {
+                            return new IllegalStateException()
+                        }))
+                    })
         }
     }
 }

--- a/rxjava3/src/main/java/io/micronaut/rxjava3/instrument/RxJava3Instrumentation.java
+++ b/rxjava3/src/main/java/io/micronaut/rxjava3/instrument/RxJava3Instrumentation.java
@@ -26,7 +26,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
 /**
- * Provides a single point of entry for all instrumentations for RxJava 2.x.
+ * Provides a single point of entry for all instrumentation for RxJava 3.x.
  *
  * @author Graeme Rocher
  * @since 1.0


### PR DESCRIPTION
RxJava3ConverterRegistrar is updated to wrap the source Publisher in a context-aware publisher
that propagates any available context when converting to an RxJava type.

This solves the general case where the internal Micronaut implementation is using Reactor types
and the Reactor context API, but then the type is converted to an RxJava type such as Flowable
as required by the user's code. For example, this happens when applying the declarative HttpClient
to a user's interface or abstract class that uses RxJava types.

This resolves #306.
